### PR TITLE
Added rake task to fetch spec version from github and update it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,25 @@ task :spec do
   # Provide your own implementation
 end
 
+task :version do
+  puts "-- fetching version number from github"
+  sh 'git fetch'
+
+  puts "The current released version of your pod is " + current_released_version
+  print "Enter the version you want to release (" + suggested_version + ") "
+  new_version = $stdin.gets.strip
+  if new_version == ""
+    new_version = suggested_version
+  end
+
+  replace_version_number(new_version)
+end
+
 desc "Release a new version of the Pod"
 task :release do
+
+  puts "* Running version"
+  sh "rake version"
 
   unless ENV['SKIP_CHECKS']
     if `git symbolic-ref HEAD 2>/dev/null`.strip.split('/').last != 'master'
@@ -19,20 +36,11 @@ task :release do
 
     puts "You are about to release `#{spec_version}`, is that correct? [y/n]"
     exit if $stdin.gets.strip.downcase != 'y'
-
-    diff_lines = `git diff --name-only`.strip.split("\n")
-
-
-    diff_lines.delete('CHANGELOG.md')
-    if diff_lines != [podspec_path]
-      $stderr.puts "[!] Only change the version number in a release commit!"
-      exit 1
-    end
   end
 
   puts "* Running specs"
   sh "rake spec"
-
+ 
   puts "* Linting the podspec"
   sh "pod lib lint"
 
@@ -63,3 +71,30 @@ def podspec_path
   end
 end
 
+def current_released_version
+  diff_version_lines = `git diff *.podspec | grep \'\\-  s.version\'`.strip.split("\n")
+  if diff_version_lines.count == 0
+    spec_version.to_s()
+  else
+    diff_version_line = diff_version_lines.first
+    remote_version = diff_version_line.split("=").last.strip.gsub("\"","").gsub("\'","")
+    remote_version
+  end
+end
+
+def suggested_version
+  if spec_version.to_s() != current_released_version
+    spec_version.to_s()
+  else
+    version_components = spec_version.to_s().split(".");
+    last = (version_components.last.to_i() + 1).to_s
+    version_components[-1] = last
+    version_components.join(".")
+  end
+end
+
+def replace_version_number(new_version_number)
+  text = File.read(podspec_path)
+  text.gsub!(/(s.version( )*= ")#{spec_version}(")/, "\\1#{new_version_number}\\3")
+  File.open(podspec_path, "w") { |file| file.puts text }
+end


### PR DESCRIPTION
I added a rake task that:
- displays the currently deployed version number of the pod
- suggests a new version number
- let the user specify a different version number
- update the podspec file

I chose to make the rake command interactive so that it can display the current released version and suggest a new version.

here is an example output:

```
$ rake release
* Running version
rake version
-- fetching version number from github
git fetch
The current released version of your pod is 0.1.1
Enter the version you want to release (0.1.2) 0.2.0
You are about to release `0.2.0`, is that correct? [y/n]
y
* Running specs
rake spec
* Linting the podspec
pod lib lint
...
```
