### PR TITLE
Remove Pods directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ DerivedData
 *.hmap
 *.ipa
 
-# CocoaPods
-Pods


### PR DESCRIPTION
Committing the Pods directory of the demo project seems to be a more sane default.
The demo project should be able to build right after checkout without the need to run `pod install` or even installing CocoaPods.
If the library author doesn't like to commit the Pods directory he can still add it to the local .gitignore or it's already in the global gitignore.
