### PR TITLE
Allow override of spec repo name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :version do
   replace_version_number(new_version_number)
 end
 
-desc "Release a new version of the Pod"
+desc "Release a new version of the Pod (append repo=name to push to a private spec repo)"
 task :release do
   # Allow override of spec repo name using `repo=private` after task name
   repo = ENV["repo"] || "master"


### PR DESCRIPTION
**Syntax: `rake release repo=private`**

This template is incredibly useful, but the one thing I have to customize on every internal pod we `pod lib create` is the line which calls out the spec repo name. While changing that to the internal spec repo name (every time) works, that approach also depends on every dev naming their spec repo exactly same.

This pull request not only allows for developers publishing to private repos to do so very easily, but it also allows for the flexibility of the name of the private repo name to vary among local CocoaPod configurations. And, of course, the default spec repo is master when not specified.

---

While it's possible to pass args in a `rake release[privaterepo]` fashion, this seems foreign on the command line. However, the extra brackets do show up in the `rake -T` output improving discoverability. 

```
$ rake -T
rake release[specrepo]  # Release a new version of the Pod
rake spec           # Runs the specs [EMPTY]
```

Any way to customize the `rake -T` output? 
