### PR TITLE
Change NAME to EXAMPLE in social_media_url

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = { "${USER_NAME}" => "${USER_EMAIL}" }
   s.source           = { :git => "http://EXAMPLE/NAME.git", :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/NAME'
+  s.social_media_url = 'https://twitter.com/EXAMPLE'
 
   # s.platform     = :ios, '5.0'
   # s.ios.deployment_target = '5.0'


### PR DESCRIPTION
According to the suggestion of @irrationalfab in CocoaPods/CocoaPods#1927.
Working on a pull request for CocoaPods/Core to lint this.
