### PR TITLE
[Rakefile] Use new pod push subcommands

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :version do
           remote_spec_version.to_s()
     version = suggested_version_number
   end
-  
+
   puts "Enter the version you want to release (" + version + ") "
   new_version_number = $stdin.gets.strip
   if new_version_number == ""
@@ -56,7 +56,7 @@ task :release do
 
   puts "* Running specs"
   sh "rake spec"
- 
+
   puts "* Linting the podspec"
   sh "pod lib lint"
 


### PR DESCRIPTION
Update final step of release task to issue different commands (based on presence of repo= optional arg)
- master (trunk): `pod trunk push ...`
- private: `pod repo push ...`
