### PR TITLE
Use xcodebuild as default build tool and maybe add a task file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 # before_install: cd Example && pod install && cd -
 install:
-- gem install xcpretty
+- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
 - set -o pipefail && xcodebuild test -workspace Example/${POD_NAME}.xcworkspace -scheme ${POD_NAME} -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c


### PR DESCRIPTION
## Changes
- Swaps `xcodebuild` for `xctool` in `.travis.yml`
- Adds `xcpretty` as a build output formatter
## Rationale
- The build is not using the features of xctool like parallelization, and just needs a formatter
- We should avoid some of the compatibility issues between `xcodebuild` and `xctool` which may confuse new pod authors, like:
  - [The simulator failed to start, or the TEST_HOST application failed to run](https://github.com/facebook/xctool/issues/274)
  - [xctool fails to find schemes in sub-projects but xcodebuild works](https://github.com/facebook/xctool/issues/365)
## Discussion
- Not sure if these concerns override the [original rationale for using xctool](https://github.com/CocoaPods/pod-template/pull/54#discussion_r14232096) (not adding additional dependencies)
- This change doesn't add a task file ([Rakefile](https://github.com/AFNetworking/AFNetworking/blob/master/Rakefile) or [Makefile](https://github.com/kattrali/SimpleSyncService/blob/master/Makefile)), which is what I would actually do when making a pod. Important commands should not only committed to a service-specific file. Maybe we should add one?
  - If there is a task file, `xcodebuild` probably makes the most sense, since even if Travis has `xctool` by default, the average pod writer may not

Thoughts?
