### PR TITLE
Change remove demo to select by @configurator.pod_name

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -58,7 +58,7 @@ module Pod
       end
 
       # Remove the references in xcode
-      project_app_group = @project.root_object.main_group.children.select { |group| group.display_name == "PROJECT" }.first
+      project_app_group = @project.root_object.main_group.children.select { |group| group.display_name == @configurator.pod_name }.first
       project_app_group.remove_from_project
 
       # Remove the actual folder + files


### PR DESCRIPTION
running into this problem where opting for no demo would break the ProjectManipulator.
Seems like the rename process is happening in `replace_internal_project_settings` before the call to `remove_demo_project` causing `group.display_name == "PROJECT"` to fail

The simple fix was to use the @configurator object to get the correct project name to remove. 

Error below:

```
justins-mbp:ios_pods justin$ pod lib create ZumperDataSync
Cloning `https://github.com/CocoaPods/pod-template.git` into `ZumperDataSync`.
Configuring ZumperDataSync template.

------------------------------

To get you started we need to ask 4 questions, this should only take a minute.

If this is your first time we recommend running through with the guide: 
 - http://guides.cocoapods.org/making/using-pod-lib-create.html
 ( hold cmd and double click links to open in a browser. )


Would you like to have a demo for your library? [ Yes / No ]
 > No

Which testing frameworks will you use? [ Specta / Kiwi ]
 > 
specta
Would you like to do view based testing? [ Yes / No ]
 > No

What is your class prefix?
 > ZUM
/Users/justin/Zumper/ios_pods/ZumperDataSync/setup/ProjectManipulator.rb:62:in `remove_demo_project': undefined method `remove_from_project' for nil:NilClass (NoMethodError)
    from /Users/justin/Zumper/ios_pods/ZumperDataSync/setup/ProjectManipulator.rb:31:in `run'
    from /Users/justin/Zumper/ios_pods/ZumperDataSync/setup/ConfigureiOS.rb:66:in `perform'
    from /Users/justin/Zumper/ios_pods/ZumperDataSync/setup/ConfigureiOS.rb:7:in `perform'
    from /Users/justin/Zumper/ios_pods/ZumperDataSync/setup/TemplateConfigurator.rb:72:in `run'
    from ./configure:9:in `<main>'

To learn more about the template see `https://github.com/CocoaPods/pod-template.git`.
To learn more about creating a new pod, see `http://guides.cocoapods.org/making/making-a-cocoapod`.
```
