### PR TITLE
Travis: Bump CocoaPods version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@
 language: objective-c
 # cache: cocoapods
 # podfile: Example/Podfile
-# before_install: cd Example && pod install && cd -
+# before_install:
+# - gem install cocoapods # Since Travis is not always on latest version
+# - pod install --project-directory=Example
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:


### PR DESCRIPTION
- Travis is not always on latest CocoaPods. If a developer is on latest and Travis is not, CocoaPods warns about conflicts on startup.
- Use a subshell instead of `cd -`.
