### PR TITLE
Avoid naming clash between example and resource bundle scheme.

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -81,7 +81,7 @@ module Pod
 
       # shared schemes have project specific names
       scheme_path = project_folder + "/PROJECT.xcodeproj/xcshareddata/xcschemes/"
-      File.rename(scheme_path + "PROJECT.xcscheme", scheme_path +  @configurator.pod_name + ".xcscheme")
+      File.rename(scheme_path + "PROJECT.xcscheme", scheme_path +  @configurator.pod_name + "-Example.xcscheme")
 
       # rename xcproject
       File.rename(project_folder + "/PROJECT.xcodeproj", project_folder + "/" +  @configurator.pod_name + ".xcodeproj")


### PR DESCRIPTION
As the resource bundle and the example target share the same name, their schemes will clash when using `xcodebuild`. This fix avoids it by changing the example target scheme name to 'podname-Example'.

Fixes #81.
