### PR TITLE
Refactor Travis rig so devs can run tests locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 # references:
 # * http://www.objc.io/issue-6/travis-ci.html
-# * https://github.com/supermarin/xcpretty#usage
 
 language: objective-c
 # cache: cocoapods
 # podfile: Example/Podfile
-# before_install:
-# - gem install cocoapods # Since Travis is not always on latest version
-# - pod install --project-directory=Example
-install:
-- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-script:
-- set -o pipefail && xcodebuild test -workspace Example/${POD_NAME}.xcworkspace -scheme ${POD_NAME}-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
+install: rake install_for_ci
+script: rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,39 @@
+# origin: https://github.com/CocoaPods/pod-template
+#
+# references:
+# * http://www.objc.io/issue-6/travis-ci.html
+# * https://github.com/supermarin/xcpretty#usage
+
+$pod_name = '${POD_NAME}'
+$scheme_args = "-workspace Example/#{$pod_name}.xcworkspace -scheme #{$pod_name}-Example"
+
+task :install_pods do
+  raise unless system "pod install --project-directory=Example"
+end
+
+desc "Install development dependencies"
+task :install => :install_pods do
+  puts
+  puts "Installing xcpretty gem with sudo."
+  puts
+  raise unless system "sudo -k gem install xcpretty"
+end
+
+task :install_for_ci do
+  # Uncomment if Pods/ is in .gitignore
+  # raise unless system "gem install cocoapods --no-rdoc --no-ri --no-document --quiet" # Since Travis is not always on latest version
+  # Rake::Task['install_pods'].invoke
+
+  raise unless system "gem install xcpretty --no-rdoc --no-ri --no-document --quiet"
+end
+
+desc "Run tests on the iOS Simulator"
+task :test do
+  raise unless system "bash -c 'set -o pipefail && xcodebuild test #{$scheme_args} -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c'"
+end
+
+desc "Clean build"
+task :clean do
+  raise unless system "xcodebuild clean #{$scheme_args}"
+end
+

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -100,7 +100,7 @@ module Pod
     end
 
     def replace_variables_in_files
-      file_names = ['POD_LICENSE', 'POD_README.md', 'NAME.podspec', '.travis.yml', podfile_path]
+      file_names = ['POD_LICENSE', 'POD_README.md', 'NAME.podspec', 'Rakefile', podfile_path]
       file_names.each do |file_name|
         text = File.read(file_name)
         text.gsub!("${POD_NAME}", @pod_name)


### PR DESCRIPTION
When using this template I moved the test command into a rake task, which makes it more convenient to run tests locally. In particular I had a bug which Travis uncovered – a legitimate memory bug – which manifested consistently in xcodebuild but not in Xcode itself. Autoreleasing behaves a little bit differently between the two.

The point is, it's useful for a developer to easily run the tests locally.

It's also easier to bring new contributors into a project when the dev installation is scripted.

This change adds a layer of indirection through rake. I'm not normally a fan of indirection, but I do think developers should be able to run the tests locally. A shell script would work here, but in my experience projects quickly outgrow them and they are harder to read.
