### PR TITLE
Fix syntax of Specta test example template

### DIFF
--- a/setup/test_examples/specta.m
+++ b/setup/test_examples/specta.m
@@ -15,8 +15,6 @@ describe(@"these will fail", ^{
         
         });
     });
-
-    });
 });
 
 describe(@"these will pass", ^{


### PR DESCRIPTION
Removed extraneous `});` from the Specta test template