### PR TITLE
Fix example specta test that won’t compile

### DIFF
--- a/setup/test_examples/specta.m
+++ b/setup/test_examples/specta.m
@@ -27,7 +27,7 @@ describe(@"these will pass", ^{
         expect(@"team").toNot.contain(@"I");
     });
 
-    it(@"will wait and succeed", ^AsyncBlock {
+    it(@"will wait and succeed", ^{
         waitUntil(^(DoneCallback done) {
             done();
         });

--- a/setup/test_examples/specta.m
+++ b/setup/test_examples/specta.m
@@ -9,24 +9,24 @@ describe(@"these will fail", ^{
     it(@"can read", ^{
         expect(@"number").to.equal(@"string");
     });
-    
+
     it(@"will wait for 10 seconds and fail", ^{
         waitUntil(^(DoneCallback done) {
-        
+
         });
     });
 });
 
 describe(@"these will pass", ^{
-    
+
     it(@"can do maths", ^{
         expect(1).beLessThan(23);
     });
-    
+
     it(@"can read", ^{
         expect(@"team").toNot.contain(@"I");
     });
-    
+
     it(@"will wait and succeed", ^AsyncBlock {
         waitUntil(^(DoneCallback done) {
             done();


### PR DESCRIPTION
Removes `^AsyncBlock` and replaces it with `waitUntil`, a [breaking change in specta 0.3][c]. Keeping `^AsyncBlock` in there prevents the tests from compiling.

[c]: https://github.com/specta/specta/commit/fe69ac5e63604af80ee8e540517566f6ebb9aaf0
