### PR TITLE
Fixed Test.m template not being set up with *None* test framework.

### DIFF
--- a/setup/ConfigureiOS.rb
+++ b/setup/ConfigureiOS.rb
@@ -33,6 +33,8 @@ module Pod
           configurator.set_test_framework("kiwi")
 
         when :none
+          configurator.add_line_to_pch "#import <XCTest/XCTest.h>"
+          configurator.set_test_framework("xctest")
       end
 
       snapshots = configurator.ask_with_answers("Would you like to do view based testing", ["Yes", "No"]).to_sym

--- a/setup/ConfigureiOS.rb
+++ b/setup/ConfigureiOS.rb
@@ -33,7 +33,6 @@ module Pod
           configurator.set_test_framework("kiwi")
 
         when :none
-          configurator.add_line_to_pch "#import <XCTest/XCTest.h>"
           configurator.set_test_framework("xctest")
       end
 

--- a/setup/test_examples/xctest.m
+++ b/setup/test_examples/xctest.m
@@ -1,3 +1,5 @@
+#import <XCTest/XCTest.h>
+
 @interface Tests : XCTestCase
 
 @end

--- a/setup/test_examples/xctest.m
+++ b/setup/test_examples/xctest.m
@@ -1,0 +1,24 @@
+@interface Tests : XCTestCase
+
+@end
+
+@implementation Tests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample
+{
+    XCTFail(@"No implementation for \"%s\"", __PRETTY_FUNCTION__);
+}
+
+@end


### PR DESCRIPTION
Fixed `Test.m` template not being set up when selecting test framework: *None*.
Now assumes `XCTest` and applies a template to the test prefix header and `Test.m` example.

I don't see anything about the default 'test framework' when choosing *None* in the CocoaPods.org guide. `XCTest` makes sense as a default, so no changes required to the guide.