### PR TITLE
Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ DerivedData
 # Bundler
 .bundle
 
+Carthage
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -85,6 +85,7 @@ module Pod
       rename_template_files
       add_pods_to_podfile
       customise_prefix
+      ensure_carthage_compatibility
       reinitialize_git_repo
       run_pod_install
 
@@ -93,6 +94,11 @@ module Pod
 
     #----------------------------------------#
 
+    def ensure_carthage_compatibility
+      FileUtils.ln_s('Example/Pods/Pods.xcodeproj', '_Carthage.xcodeproj')
+      FileUtils.ln_s("Example/#{pod_name}.xcworkspace", '_Carthage.xcworkspace')
+    end
+
     def run_pod_install
       puts "\nRunning " + "pod install".magenta + " on your new library."
       puts ""
@@ -100,9 +106,6 @@ module Pod
       Dir.chdir("Example") do
         system "pod install"
       end
-
-      FileUtils.ln_s('Example/Pods/Pods.xcodeproj', '_Carthage.xcodeproj')
-      FileUtils.ln_s("Example/#{pod_name}.xcworkspace", '_Carthage.xcworkspace')
     end
 
     def clean_template_files

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -100,6 +100,8 @@ module Pod
       Dir.chdir("Example") do
         system "pod install"
       end
+
+      FileUtils.ln_s('Example/Pods/Pods.xcodeproj', '_Carthage.xcodeproj')
     end
 
     def clean_template_files

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -96,7 +96,6 @@ module Pod
 
     def ensure_carthage_compatibility
       FileUtils.ln_s('Example/Pods/Pods.xcodeproj', '_Carthage.xcodeproj')
-      FileUtils.ln_s("Example/#{pod_name}.xcworkspace", '_Carthage.xcworkspace')
     end
 
     def run_pod_install

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -102,6 +102,7 @@ module Pod
       end
 
       FileUtils.ln_s('Example/Pods/Pods.xcodeproj', '_Carthage.xcodeproj')
+      FileUtils.ln_s("Example/#{pod_name}.xcworkspace", '_Carthage.xcworkspace')
     end
 
     def clean_template_files


### PR DESCRIPTION
This allows pod-template projects to be buildable with Carthage by default. Prerequisite from the user side will be checking in their `Example/Pods` directory, as well as the generated workspace.

:warning: This depends on some changes to both CocoaPods and Carthage, before it is useful:

- [x] CocoaPods/CocoaPods#3600, which shares schemes for development pods
- [x] Carthage/Carthage#489, symlink support in Carthage
- [x] Carthage/Carthage#488, limit Carthage to build only shared schemes (technically not required, but all pods schemes would be build if they happen to exist, e.g. after a `pod install`)

If the user adds dependencies, he will have to add a `Cartfile` to also make them known to Carthage.

Fixes #104 