### PR TITLE
Re-add the example project after `pod install`.

### DIFF
--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -100,6 +100,9 @@ module Pod
       Dir.chdir("Example") do
         system "pod install"
       end
+
+      `git add Example/#{pod_name}.xcodeproj/project.pbxproj`
+      `git commit -m "Initial commit"`
     end
 
     def clean_template_files
@@ -167,7 +170,6 @@ module Pod
       `rm -rf .git`
       `git init`
       `git add -A`
-      `git commit -m "Initial commit"`
     end
 
     def validate_user_details


### PR DESCRIPTION
Currently, this will be the state of the project after setting it up

```bash
$ git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   Example/yolo.xcodeproj/project.pbxproj

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	Example/Podfile.lock
	Example/Pods/
	Example/yolo.xcworkspace/

no changes added to commit (use "git add" and/or "git commit -a")
```

While it makes sense to not check-in the files generated by CP, because of user-choice and education reasons, I don't think it is useful that the example project itself ends up in an unclean state. This is only a recipe for confusion and not committing it to source control is not an option anyway.

Therefore, we should perform the initial commit after `pod install`.