### PR TITLE
Fix crash due to missing storyboard file

### DIFF
--- a/templates/ios/Example/PROJECT/PROJECT-Info.plist
+++ b/templates/ios/Example/PROJECT/PROJECT-Info.plist
@@ -25,9 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>
-	<string>Main_iPhone</string>
-	<key>UIMainStoryboardFile~ipad</key>
-	<string>Main_iPad</string>
+	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Updates `PROJECT-Info.plist` to reflect changes made in #116 where the main storyboard was changed for Objective-C projects.