### PR TITLE
Xcode 7 support

### DIFF
--- a/setup/MessageBank.rb
+++ b/setup/MessageBank.rb
@@ -66,7 +66,7 @@ module Pod
       puts " Ace! you're ready to go!"
       puts " We will start you off by opening your project in Xcode"
       pod_name = @configurator.pod_name
-      run_command "open 'Example/#{pod_name}.xcworkspace'", "open '#{pod_name}/Example/#{pod_name}.xcworkspace'"
+      run_command "open -a Xcode-beta 'Example/#{pod_name}.xcworkspace'", "open '#{pod_name}/Example/#{pod_name}.xcworkspace'"
     end
 
 

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -139,6 +139,10 @@ module Pod
       podfile_content = @pods_for_podfile.map do |pod|
         "pod '" + pod + "'"
       end.join("\n  ")
+
+      # Update pods with temporary Swift 2.0 versions
+      podfile_content.sub!("Nimble'", "Nimble', '= 2.0.0-rc.1'")
+      podfile_content.sub!("Nimble-Snapshots'", "Nimble-Snapshots', :git => 'https://github.com/pjenkins-cc/Nimble-Snapshots.git', :branch => 'swift-2.0'")
       podfile.gsub!("${INCLUDED_PODS}", podfile_content)
       File.open(podfile_path, "w") { |file| file.puts podfile }
     end

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -70,7 +70,7 @@ module Pod
     def run
       @message_bank.welcome_message
 
-      framework = self.ask_with_answers("What language do you want to use?", ["ObjC", "Swift"]).to_sym
+      framework = self.ask_with_answers("What language do you want to use?", ["Swift", "ObjC"]).to_sym
       case framework
         when :swift
           ConfigureSwift.perform(configurator: self)


### PR DESCRIPTION
This template will produce CocoaPods that work with Xcode 7 and Swift 2.0.

Here's how to use it:

1. `$ pod _0.37.0_ lib create MyPod https://github.com/pjenkins-cc/pod-template-swift-2.0`
1. Click Cancel when prompted to convert to the latest Swift syntax.

Once swift-2.0 changes are eventually merged upstream, the subs in TemplateConfigurator.rb can be removed.

This will break people wanting to use Swift with Xcode 6, so it shouldn't go into master right now. But I'm creating the PR anyway, per discussion in #117.

Edit: Added `_0.37.0_` above because this isn't working at the moment with CocoaPods 0.38.0. So this assumes you still have 0.37.0 installed. Otherwise, `$ sudo gem install cocoapods:0.37.0`