### PR TITLE
Fixed typo and run passing examples.

### DIFF
--- a/setup/test_examples/quick.swift
+++ b/setup/test_examples/quick.swift
@@ -31,7 +31,7 @@ class TableOfContentsSpec: QuickSpec {
                 expect("🐮") == "🐮"
             }
 
-            it("will exentually pass") {
+            it("will eventually pass") {
                 var time = "passing"
 
                 dispatch_async(dispatch_get_main_queue()) {

--- a/setup/test_examples/quick.swift
+++ b/setup/test_examples/quick.swift
@@ -19,30 +19,30 @@ class TableOfContentsSpec: QuickSpec {
             it("will eventually fail") {
                 expect("time").toEventually( equal("done") )
             }
-        }
+            
+            context("these will pass") {
 
-        context("these will pass") {
-
-            it("can do maths") {
-                expect(23) == 23
-            }
-
-            it("can read") {
-                expect("🐮") == "🐮"
-            }
-
-            it("will eventually pass") {
-                var time = "passing"
-
-                dispatch_async(dispatch_get_main_queue()) {
-                    time = "done"
+                it("can do maths") {
+                    expect(23) == 23
                 }
 
-                waitUntil { done in
-                    NSThread.sleepForTimeInterval(0.5)
-                    expect(time) == "done"
+                it("can read") {
+                    expect("🐮") == "🐮"
+                }
 
-                    done()
+                it("will eventually pass") {
+                    var time = "passing"
+
+                    dispatch_async(dispatch_get_main_queue()) {
+                        time = "done"
+                    }
+
+                    waitUntil { done in
+                        NSThread.sleepForTimeInterval(0.5)
+                        expect(time) == "done"
+
+                        done()
+                    }
                 }
             }
         }


### PR DESCRIPTION
The Quick test example had a small typo, so I fixed that.

Also, when I ran my tests in Xcode 7 Beta 2, the passing tests failed to run at all. I saw other examples that put the `context` within the `describe`, so did that here as well.

This did uncover a bug (probably in Quick itself?), namely that the test `will eventually pass` does not appear to be run at all.

![screen shot 2015-06-28 at 10 42 30](https://cloud.githubusercontent.com/assets/904596/8395733/89e0f5d2-1d82-11e5-95cb-8c5d96483886.png)
