### PR TITLE
fixing project imports and Podfile for ios sdk older than 8

### DIFF
--- a/setup/ConfigureiOS.rb
+++ b/setup/ConfigureiOS.rb
@@ -21,35 +21,41 @@ module Pod
           configurator.add_pod_to_podfile "Specta"
           configurator.add_pod_to_podfile "Expecta"
 
-          configurator.add_line_to_pch "@import Specta;"
-          configurator.add_line_to_pch "@import Expecta;"
+          configurator.add_line_to_pch "#import <Specta/Specta.h>"
+          configurator.add_line_to_pch "#import <Expecta/Expecta.h>"
 
           configurator.set_test_framework("specta", "m")
 
         when :kiwi
           configurator.add_pod_to_podfile "Kiwi"
-          configurator.add_line_to_pch "@import Kiwi;"
+          configurator.add_line_to_pch "#import <Kiwi/Kiwi.h>"
           configurator.set_test_framework("kiwi", "m")
 
         when :none
           configurator.set_test_framework("xctest", "m")
       end
 
-      snapshots = configurator.ask_with_answers("Would you like to do view based testing", ["Yes", "No"]).to_sym
-      case snapshots
-        when :yes
-          configurator.add_pod_to_podfile "FBSnapshotTestCase"
-          configurator.add_line_to_pch "@import FBSnapshotTestCase;"
+      platform = configurator.ask_with_answers("Are you going to support iOS platforms older than 8.0", ["Yes", "No"]).to_sym
+      if platform == :yes
+          configurator.set_platform_ios7
+      
+      else
+        snapshots = configurator.ask_with_answers("Would you like to do view based testing", ["Yes", "No"]).to_sym
+        case snapshots
+          when :yes
+            configurator.add_pod_to_podfile "FBSnapshotTestCase"
+            configurator.add_line_to_pch "@import FBSnapshotTestCase;"
 
-          if keep_demo == :no
-              puts " Putting demo application back in, you cannot do view tests without a host application."
-              keep_demo = :yes
-          end
+            if keep_demo == :no
+                puts " Putting demo application back in, you cannot do view tests without a host application."
+                keep_demo = :yes
+            end
 
-          if framework == :specta
-              configurator.add_pod_to_podfile "Expecta+Snapshots"
-              configurator.add_line_to_pch "@import Expecta_Snapshots;"
-          end
+            if framework == :specta
+                configurator.add_pod_to_podfile "Expecta+Snapshots"
+                configurator.add_line_to_pch "@import Expecta_Snapshots;"
+            end
+        end
       end
 
       prefix = nil

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -130,6 +130,13 @@ module Pod
       end
     end
 
+    def set_platform_ios7
+      template_podfile_path = "templates/ios/Example/Podfile"
+      text = File.read(template_podfile_path)
+      text.gsub!('use_frameworks!', "platform :ios,'7.0'")
+      File.open(template_podfile_path, "w") { |file| file.puts text }
+    end
+    
     def add_pod_to_podfile podname
       @pods_for_podfile << podname
     end


### PR DESCRIPTION
I noticed that cocoapods is supporting swift now. When i create a new project and select a test framework, i get @imports added to Tests.pch file and errors of module not found in Xcode.

To fix that, i changed @imports to the correct #include.
Another thing is the use of use_frameworks! in Podfile that is not supported in ios sdk older than 8.
This pull requests adds a question to pod lib create that asks if the project will support ios older than 8 and in case it does, we change use_frameworks! for platform :ios, '7.0'.
In case the user selects no, nothing is changed.