### PR TITLE
Don't use the `--quick` option for pod lib lint in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ language: objective-c
 # - pod install --project-directory=Example
 script:
 - set -o pipefail && xcodebuild test -workspace Example/${POD_NAME}.xcworkspace -scheme ${POD_NAME}-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty
-- pod lib lint --quick
+- pod lib lint


### PR DESCRIPTION
This means that your pod will by built for all platforms by CocoaPods and fully lint your podspec so you don't come into surprises when you try to release for real and it doesn't work.