### PR TITLE
Update Quick version

### DIFF
--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -17,7 +17,7 @@ module Pod
       framework = configurator.ask_with_answers("Which testing frameworks will you use", ["Quick", "None"]).to_sym
       case framework
         when :quick
-          configurator.add_pod_to_podfile "Quick', '~> 0.8.0"
+          configurator.add_pod_to_podfile "Quick', '0.8.0"
           configurator.add_pod_to_podfile "Nimble', '3.0.0"
           configurator.set_test_framework "quick", "swift"
 

--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -17,7 +17,7 @@ module Pod
       framework = configurator.ask_with_answers("Which testing frameworks will you use", ["Quick", "None"]).to_sym
       case framework
         when :quick
-          configurator.add_pod_to_podfile "Quick', '0.8.0"
+          configurator.add_pod_to_podfile "Quick', '~> 0.8.0"
           configurator.add_pod_to_podfile "Nimble', '3.0.0"
           configurator.set_test_framework "quick", "swift"
 

--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -17,8 +17,8 @@ module Pod
       framework = configurator.ask_with_answers("Which testing frameworks will you use", ["Quick", "None"]).to_sym
       case framework
         when :quick
-          configurator.add_pod_to_podfile "Quick', '~> 0.3.1"
-          configurator.add_pod_to_podfile "Nimble"
+          configurator.add_pod_to_podfile "Quick', '~> 0.8.0"
+          configurator.add_pod_to_podfile "Nimble', '3.0.0"
           configurator.set_test_framework "quick", "swift"
 
         when :none


### PR DESCRIPTION
I try this command.
`pod lib create TestProject` and Select `Swift` , `Quick` 

Using Xcode 7.1 with Quick 0.3.1 leads errors and build does not success.
Quick version should be 0.8.0 written in documentation of Quick.

Do we have some reason using 0.3.1 which I have not taken care of ?