### PR TITLE
this currently updates the default Nimble to be used for new pods to …

### DIFF
--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -17,8 +17,8 @@ module Pod
       framework = configurator.ask_with_answers("Which testing frameworks will you use", ["Quick", "None"]).to_sym
       case framework
         when :quick
-          configurator.add_pod_to_podfile "Quick', '~> 0.8.0"
-          configurator.add_pod_to_podfile "Nimble', '3.0.0"
+          configurator.add_pod_to_podfile "Quick', '~> 0.8"
+          configurator.add_pod_to_podfile "Nimble', '~> 3.0"
           configurator.set_test_framework "quick", "swift"
 
         when :none


### PR DESCRIPTION
…3.2 and keeps up with other minor releases in the future

As explained and discussed here: https://github.com/CocoaPods/CocoaPods/issues/5074