### PR TITLE
Move the files for the pod into a folder with the same name as the project

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
 #   * Think: What does it do? Why did you write it? What is the focus?
 #   * Try to keep it short, snappy and to the point.
 #   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!  
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
   s.description      = <<-DESC
                        DESC
 
@@ -26,12 +27,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/<GITHUB_USERNAME>/${POD_NAME}.git", :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.platform     = :ios, '7.0'
-  s.requires_arc = true
+  s.platform     = :ios, '8.0'
 
-  s.source_files = 'Pod/Classes/**/*'
+  s.source_files = '${POD_NAME}/Classes/**/*'
   s.resource_bundles = {
-    '${POD_NAME}' => ['Pod/Assets/*.png']
+    '${POD_NAME}' => ['${POD_NAME}/Assets/*.png']
   }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'

--- a/setup/MessageBank.rb
+++ b/setup/MessageBank.rb
@@ -29,7 +29,6 @@ module Pod
       system command
     end
 
-
     def welcome_message
       unless @configurator.validate_user_details
         run_setup_questions
@@ -39,7 +38,7 @@ module Pod
       puts ""
       puts "To get you started we need to ask a few questions, this should only take a minute."
       puts ""
-      
+
       has_run_before = `defaults read org.cocoapods.pod-template HasRunbefore`.chomp == "1"
 
       puts "If this is your first time we recommend running through with the guide: "
@@ -50,12 +49,11 @@ module Pod
       else
         puts " ( hold cmd and double click links to open in a browser. )".magenta
       end
-      
+
       unless has_run_before
         puts "\n Press return to continue."
         `defaults write org.cocoapods.pod-template HasRunbefore -bool true`
       end
-      
 
       puts ""
     end

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -79,12 +79,12 @@ module Pod
           ConfigureIOS.perform(configurator: self)
       end
 
-
       replace_variables_in_files
       clean_template_files
       rename_template_files
       add_pods_to_podfile
       customise_prefix
+      rename_classes_folder
       ensure_carthage_compatibility
       reinitialize_git_repo
       run_pod_install
@@ -169,6 +169,10 @@ module Pod
       FileUtils.mv "POD_README.md", "README.md"
       FileUtils.mv "POD_LICENSE", "LICENSE"
       FileUtils.mv "NAME.podspec", "#{pod_name}.podspec"
+    end
+
+    def rename_classes_folder
+      FileUtils.mv "POD", @pod_name
     end
 
     def reinitialize_git_repo

--- a/templates/swift/Example/Podfile
+++ b/templates/swift/Example/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 target '${POD_NAME}_Example', :exclusive => true do


### PR DESCRIPTION
In the current version, your files would go into `Pod/Classes/Here.swift` but I think overall, it's less confusing to have them go into `[LibName]/Classes/Here.swift`.

Other than that, done some minor cleanup.