### PR TITLE
Fix Podfile generated when a project has no example app

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -73,7 +73,7 @@ module Pod
       # Remove the section in the Podfile for the lib by removing top 3 lines after the source + using_frameworks!
       podfile_path = project_folder + "/Podfile"
       podfile_lines = File.read(podfile_path).lines
-      3.times do  podfile_lines.delete_at 3 end
+      3.times do  podfile_lines.delete_at 2 end
       podfile_text = podfile_lines.join
       File.open(podfile_path, "w") { |file| file.puts podfile_text }
     end

--- a/templates/ios/Example/Podfile
+++ b/templates/ios/Example/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 target '${POD_NAME}_Example', :exclusive => true do


### PR DESCRIPTION
After I removed the line: 

```
source 'https://github.com/CocoaPods/Specs.git'
```

it threw the offsets for the App target to be removed from the podfile:

```
use_frameworks!

target '${POD_NAME}_Example', :exclusive => true do
  pod '${POD_NAME}', :path => '../'
end

target '${POD_NAME}_Tests', :exclusive => true do
  pod '${POD_NAME}', :path => '../'

  ${INCLUDED_PODS}
end
```

Where it used to delete 3 LOC from the 3rd line, it now needed to be 2 LOC. So this fixes that, and makes sure the obj-c Podfile has the same offsets.