### PR TITLE
Simplify example-less projects

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -70,14 +70,18 @@ module Pod
       `rm -rf templates/ios/Example/PROJECT`
       `rm -rf templates/swift/Example/PROJECT`
 
-      # Remove the section in the Podfile for the lib by removing top 3 lines after the source + using_frameworks!
+      # Replace the Podfile with a simpler one with only one target
       podfile_path = project_folder + "/Podfile"
-      podfile_lines = File.read(podfile_path).lines
-      3.times do  podfile_lines.delete_at 2 end
-      podfile_lines.delete_at 3 # inherit-statement
-      podfile_lines.pop  # `end` matching the target
-      podfile_text = podfile_lines.join
+      podfile_text = <<-RUBY
+use_frameworks!
+target '#{test_target.name}' do
+  pod '#{@configurator.pod_name}', :path => '../'
+  
+  ${INCLUDED_PODS}
+end
+RUBY
       File.open(podfile_path, "w") { |file| file.puts podfile_text }
+    end
     end
 
     def project_folder


### PR DESCRIPTION
previously it was doing a lot of specific line removals, which got more and more complex. Now instead it just outright replaces the podfile with a simpler, working one. This means indentation is correct, and devs need to know a lot less about the internals to understand what's going on.