### PR TITLE
[podspec] Grab the version from the current git tag

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "${POD_NAME}"
-  s.version          = "0.1.0"
+  s.version          = `git describe --tags`.chomp
   s.summary          = "A short description of ${POD_NAME}."
   s.description      = <<-DESC
                        An optional longer description of ${POD_NAME}


### PR DESCRIPTION
I am creating this PR because there is an outstanding branch open. I am hoping this can be quickly evaluated and merged or closed.

-----------

Related to CocoaPods#3308

This is very cool. But it is a little opaque and is sure to confuse somebody.

Recommending to delete git-tag-version branch and closing this PR without merge.