### PR TITLE
Fix to prevent failure in case-sensitive filesystems during setup.

### DIFF
--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -172,7 +172,7 @@ module Pod
     end
 
     def rename_classes_folder
-      FileUtils.mv "POD", @pod_name
+      FileUtils.mv "Pod", @pod_name
     end
 
     def reinitialize_git_repo


### PR DESCRIPTION
Setup using `pod lib create` was failing due to a mismatch in case-sensitivity of the Pod directory.