### PR TITLE
Grab github username if possible when expanding templates

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -21,11 +21,11 @@ Pod::Spec.new do |s|
 TODO: Add long description of the pod here.
                        DESC
 
-  s.homepage         = 'https://github.com/<GITHUB_USERNAME>/${POD_NAME}'
+  s.homepage         = 'https://github.com/${USER_NAME}/${POD_NAME}'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { '${USER_NAME}' => '${USER_EMAIL}' }
-  s.source           = { :git => 'https://github.com/<GITHUB_USERNAME>/${POD_NAME}.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/${USER_NAME}/${POD_NAME}.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '8.0'

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -188,7 +188,13 @@ module Pod
     #----------------------------------------#
 
     def user_name
-      (ENV['GIT_COMMITTER_NAME'] || `git config user.name`).strip
+      (ENV['GIT_COMMITTER_NAME'] || github_user_name || `git config user.name` || `<GITHUB_USERNAME>` ).strip
+    end
+
+    def github_user_name
+      github_user_name = `security find-internet-password -s github.com | grep acct | sed 's/"acct"<blob>="//g' | sed 's/"//g'`.strip
+      is_valid = github_user_name.empty? or github_user_name.include? '@'
+      return is_valid ? nil : github_user_name
     end
 
     def user_email


### PR DESCRIPTION
Addresses https://github.com/CocoaPods/pod-template/issues/126

Command from: http://stackoverflow.com/a/13761822/1904232

Will fallback to current behaviour if github username is not found (git username). This is still valuable to keep around as user could be setting a private pod repository in another git hosting solution.)