### PR TITLE
Update the library colored to colored2 to fix the load error in create command

### DIFF
--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'colored'
+require 'colored2'
 
 module Pod
   class TemplateConfigurator


### PR DESCRIPTION
This PR fixes the issues discussed in the issue https://github.com/CocoaPods/CocoaPods/issues/6652.

Basically, when you run pod lib create on a machine that had only the newer version of Cocoapods, it was failing with error “require': cannot load such file -- colored (LoadError)”. This is because Cocoapods does not ship with colored anymore, it only has colored2. This fix will make sure that the pod template uses the newer version and won’t fail anymore. 

@orta - As you suggested, I am creating this PR to merge this fix into master. Let me know if you need more info.
