### PR TITLE
update syntax for colored2 to fix the load error in pod lib create command

### DIFF
--- a/setup/MessageBank.rb
+++ b/setup/MessageBank.rb
@@ -42,7 +42,7 @@ module Pod
       has_run_before = `defaults read org.cocoapods.pod-template HasRunbefore`.chomp == "1"
 
       puts "If this is your first time we recommend running through with the guide: "
-      puts " - "  + "http://guides.cocoapods.org/making/using-pod-lib-create.html".blue.underline
+      puts " - "  + "http://guides.cocoapods.org/making/using-pod-lib-create.html".blue.underlined
 
       if ENV["TERM_PROGRAM"] == "iTerm.app"
         puts " ( hold cmd and click links to open in a browser. )".magenta

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -35,7 +35,7 @@ module Pod
       print_info = Proc.new {
 
         possible_answers_string = possible_answers.each_with_index do |answer, i|
-           _answer = (i == 0) ? answer.underline : answer
+           _answer = (i == 0) ? answer.underlined : answer
            print " " + _answer
            print(" /") if i != possible_answers.length-1
         end


### PR DESCRIPTION
This PR fixes the issues discussed in the issue https://github.com/CocoaPods/CocoaPods/issues/6652

Basically, when you run pod lib create on a machine that had only the newer version of Cocoapods, it still fails despite the fixed in https://github.com/CocoaPods/pod-template/pull/207 because the syntax for underline change to underlined in colored2

@orta Let me know if you need more info.