### PR TITLE
Fix indent on included pods on Podfile template

### DIFF
--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -138,7 +138,7 @@ module Pod
       podfile = File.read podfile_path
       podfile_content = @pods_for_podfile.map do |pod|
         "pod '" + pod + "'"
-      end.join("\n  ")
+      end.join("\n    ")
       podfile.gsub!("${INCLUDED_PODS}", podfile_content)
       File.open(podfile_path, "w") { |file| file.puts podfile }
     end


### PR DESCRIPTION
Before:
```
  target 'Merniva_Tests' do
    inherit! :search_paths

    pod 'Quick', '~> 1.2.0'
  pod 'Nimble', '~> 7.0.2'
  pod 'FBSnapshotTestCase' , '~> 2.1.4'
  pod 'Nimble-Snapshots' , '~> 6.3.0'
  end
```

After:
```
  target 'Merniva_Tests' do
    inherit! :search_paths

    pod 'Quick', '~> 1.2.0'
    pod 'Nimble', '~> 7.0.2'
    pod 'FBSnapshotTestCase' , '~> 2.1.4'
    pod 'Nimble-Snapshots' , '~> 6.3.0'
  end
```