### PR TITLE
fix: .gitignore removes Carthage files of dependencies (Nimble).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,11 @@ DerivedData
 # Bundler
 .bundle
 
-Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control


### PR DESCRIPTION
The problem https://github.com/Quick/Nimble/issues/490 happens even on `CocoaPods/pod-template`.
This PR will fix it.

P.S. 
I bring the code from github/gitignore:
https://github.com/github/gitignore/blob/ebb436c5590ced8ae58eea87e6400abc759f60d7/Objective-C.gitignore#L39-L44