### PR TITLE
Fixed Version Bug

### DIFF
--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -18,7 +18,7 @@ module Pod
       case framework
         when :quick
           configurator.add_pod_to_podfile "Quick', '~> 1.2.0"
-          configurator.add_pod_to_podfile "Nimble', '~> 7.0.2"
+          configurator.add_pod_to_podfile "Nimble', '~> 7.3.1"
           configurator.set_test_framework "quick", "swift", "swift"
 
         when :none


### PR DESCRIPTION
"Updated default Nimble version when building a pod library with `pod lib create NAME`. Previous version of Nimble resulted in default lib build failure. See this git issue https://github.com/CocoaPods/CocoaPods/issues/8225#issuecomment-433099759"