### PR TITLE
Add platform specification

### DIFF
--- a/templates/ios/Example/Podfile
+++ b/templates/ios/Example/Podfile
@@ -1,5 +1,7 @@
 use_frameworks!
 
+platform :ios, '8.0'
+
 target '${POD_NAME}_Example' do
   pod '${POD_NAME}', :path => '../'
 


### PR DESCRIPTION
If not present, a warning is shown on every `pod install`.

```
[!] Automatically assigning platform `ios` with version `10.0` on target `POD_NAME` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
```

Reference: https://guides.cocoapods.org/syntax/podfile.html#platform