### PR TITLE
Set SWIFT_VERSION setting for ObjC template project

### DIFF
--- a/templates/ios/Example/PROJECT.xcodeproj/project.pbxproj
+++ b/templates/ios/Example/PROJECT.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -414,6 +415,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -436,6 +438,7 @@
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PROJECT_Example.app/PROJECT_Example";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -455,6 +458,7 @@
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PROJECT_Example.app/PROJECT_Example";
 				WRAPPER_EXTENSION = xctest;
 			};


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8932

If a user creates an ObjC project then [this](https://github.com/CocoaPods/pod-template/tree/master/templates/ios/Example) template is used. However, adding a test framework which uses Swift would cause pod template creation to fail because `SWIFT_VERSION` is not set on the ObjC template anywhere. This PR adds `SWIFT_VERSION` into the `PROJECT.xcodeproj` which can be used to derive the Swift version.

All other templates used Swift 4.0 so I used that as well.