### PR TITLE
Raise default iOS `deployment_target` to 9.0

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -28,7 +28,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/${USER_NAME}/${POD_NAME}.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
 
   s.source_files = '${POD_NAME}/Classes/**/*'
   


### PR DESCRIPTION
Resolves #250 - default pods from `pod create init` will no longer cause a warning on XCode 12.