### PR TITLE
Fix iOS version number not equal between Podfile and Podspec

### DIFF
--- a/setup/ConfigureSwift.rb
+++ b/setup/ConfigureSwift.rb
@@ -48,16 +48,11 @@ module Pod
         :prefix => ""
       }).run
 
-      `mv ./templates/swift/* ./`
-
       # There has to be a single file in the Classes dir
       # or a framework won't be created
       `touch Pod/Classes/ReplaceMe.swift`
 
-      # The Podspec should be 8.0 instead of 7.0
-      text = File.read("NAME.podspec")
-      text.gsub!("7.0", "8.0")
-      File.open("NAME.podspec", "w") { |file| file.puts text }
+      `mv ./templates/swift/* ./`
 
       # remove podspec for osx
       `rm ./NAME-osx.podspec`

--- a/templates/ios/Example/Podfile
+++ b/templates/ios/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 target '${POD_NAME}_Example' do
   pod '${POD_NAME}', :path => '../'

--- a/templates/swift/Example/Podfile
+++ b/templates/swift/Example/Podfile
@@ -1,5 +1,7 @@
 use_frameworks!
 
+platform :ios, '9.0'
+
 target '${POD_NAME}_Example' do
   pod '${POD_NAME}', :path => '../'
 


### PR DESCRIPTION
iOS version number is not equal between Podfile and Podspec
This will cause an error like this:

```
[!] CocoaPods could not find compatible versions for pod "Test":
  In Podfile:
    Test (from `../`)

Specs satisfying the `Test (from `../`)` dependency were found, but they required a higher minimum deployment target.
```