### PR TITLE
OS X -> macOS in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# OS X
+# macOS
 .DS_Store
 
 # Xcode


### PR DESCRIPTION
On June 13, 2016, at WWDC16, OS X was renamed macOS.
But here in the gitignore file this hasn't changed.
Please merge it.