### PR TITLE
Update .gitignore - removing profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 !default.perspectivev3
 xcuserdata/
 *.xccheckout
-profile
 *.moved-aside
 DerivedData
 *.hmap


### PR DESCRIPTION
As pointed out in the issue #205, profile is a common folder name and with this line in the .gitignore anything inside a profile folder (not case sensitive) would be ignored. 

@orta mentioned that this line was also removed from https://github.com/github/gitignore/blob/main/Objective-C.gitignore

---

By curiosity, what was the original intention to use this profile line? Just to make sure this PR is not going against any pre-existing definition.