### PR TITLE
Update NAME.podspec

### DIFF
--- a/NAME.podspec
+++ b/NAME.podspec
@@ -28,7 +28,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/${USER_NAME}/${POD_NAME}.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
 
   s.source_files = '${POD_NAME}/Classes/**/*'
   


### PR DESCRIPTION
Raising iOS deployment_target to 10.0 in order to make it compatible with Nimble-Snapshots view based testing, and mitigate the following error:

<img width="714" alt="`pod lib create` with iOS deployment target set to 9.0 raising an error" src="https://user-images.githubusercontent.com/6471118/175375219-f97f261c-4381-4251-91d4-1f94d5f707cb.png">
