### PR TITLE
Fix 'pod install' error caused by unsatisfied minimum deployment targ…

### DIFF
--- a/templates/ios/Example/Podfile
+++ b/templates/ios/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target '${POD_NAME}_Example' do
   pod '${POD_NAME}', :path => '../'

--- a/templates/macos-swift/Example/PROJECT.xcodeproj/project.pbxproj
+++ b/templates/macos-swift/Example/PROJECT.xcodeproj/project.pbxproj
@@ -152,11 +152,11 @@
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					ED83F67720348A760038D96B = {
-						CreatedOnToolsVersion = 9.0;
+						CreatedOnToolsVersion = 10.0;
 						ProvisioningStyle = Automatic;
 					};
 					ED83F68920348A760038D96B = {
-						CreatedOnToolsVersion = 9.0;
+						CreatedOnToolsVersion = 10.0;
 						ProvisioningStyle = Automatic;
 						TestTargetID = ED83F67720348A760038D96B;
 					};

--- a/templates/swift/Example/Podfile
+++ b/templates/swift/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target '${POD_NAME}_Example' do
   pod '${POD_NAME}', :path => '../'


### PR DESCRIPTION
PR to fix issue #264 .

* Issue: Minimum deployment target mismatch(10.0 vs 9.0) causes `pod install` failure.

* What's changed: Bumped platform version in Podfile from `9.0` to `10.0`