### PR TITLE
Fix "pod lib create" error when running with Ruby 3

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -99,7 +99,7 @@ RUBY
         # change app file prefixes
         ["CPDAppDelegate.h", "CPDAppDelegate.m", "CPDViewController.h", "CPDViewController.m"].each do |file|
           before = project_folder + "/PROJECT/" + file
-          next unless File.exists? before
+          next unless File.exist? before
 
           after = project_folder + "/PROJECT/" + file.gsub("CPD", prefix)
           File.rename before, after
@@ -108,7 +108,7 @@ RUBY
         # rename project related files
         ["PROJECT-Info.plist", "PROJECT-Prefix.pch", "PROJECT.entitlements"].each do |file|
           before = project_folder + "/PROJECT/" + file
-          next unless File.exists? before
+          next unless File.exist? before
 
           after = project_folder + "/PROJECT/" + file.gsub("PROJECT", @configurator.pod_name)
           File.rename before, after
@@ -125,7 +125,7 @@ RUBY
 
     def replace_internal_project_settings
       Dir.glob(project_folder + "/**/**/**/**").each do |name|
-        next if Dir.exists? name
+        next if Dir.exist? name
         text = File.read(name)
 
         for find, replace in @string_replacements

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -156,7 +156,7 @@ module Pod
 
     def customise_prefix
       prefix_path = "Example/Tests/Tests-Prefix.pch"
-      return unless File.exists? prefix_path
+      return unless File.exist? prefix_path
 
       pch = File.read prefix_path
       pch.gsub!("${INCLUDED_PREFIXES}", @prefixes.join("\n  ") )


### PR DESCRIPTION
Because  deprecated methods `Dir.exists?`, `File.exists?` were removed from Ruby 3, you will get the following error when running `pod lib create <YourPodNname>` with Ruby 3:

```
/private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ProjectManipulator.rb:128:in `block in replace_internal_project_settings': undefined method `exists?' for Dir:Class (NoMethodError)

        next if Dir.exists? name
                   ^^^^^^^^
Did you mean?  exist?
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ProjectManipulator.rb:127:in `each'
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ProjectManipulator.rb:127:in `replace_internal_project_settings'
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ProjectManipulator.rb:28:in `run'
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ConfigureiOS.rb:73:in `perform'
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/ConfigureiOS.rb:7:in `perform'
	from /private/var/folders/mb/_fcb_z0j6knf8tphxd0fmmmm0000gp/T/play_cocoapods/MyPod/setup/TemplateConfigurator.rb:85:in `run'
	from ./configure:9:in `<main>'

To learn more about the template see `https://github.com/CocoaPods/pod-template.git`.
To learn more about creating a new pod, see `https://guides.cocoapods.org/making/making-a-cocoapod`.
```